### PR TITLE
add query and data export for deleted non-citation assertion rows

### DIFF
--- a/sql-queries/delete-non-citation-relation-types.sql
+++ b/sql-queries/delete-non-citation-relation-types.sql
@@ -1,0 +1,6 @@
+BEGIN;
+DELETE FROM public.assertions
+WHERE (relation_type_id is not null
+AND relation_type_id not in ('cites', 'is-cited-by', 'references', 'is-referenced-by', 'is-supplemented-by', 'is-supplement-to'))
+COMMIT;
+


### PR DESCRIPTION
## Purpose
- Add query used to remove assertion rows that have relation_type_id other than: cites, is-cited-by, references, is-referenced-by, is-supplemented-by, is-supplement-to or null (these types represent citations; assertions with other types should not have been included in Corpus DB)
- Add CSV with removed rows for historical reference